### PR TITLE
Feature: Updates Api-Checks module to work in JEA context

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -15,6 +15,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#5](https://github.com/Icinga/icinga-powershell-apichecks/issues/5) Fixes performance data for executed checks, which did not return an empty array if no data was available or perf data were disabled
 * [#6](https://github.com/Icinga/icinga-powershell-apichecks/issues/6) Fixes exit code to always return an integer and in case not being used, always 3 for `UNKNOWN` in Icinga context
 
+### Enhancements
+
+* [#8](https://github.com/Icinga/icinga-powershell-apichecks/pull/8) Adds support for Api-Checks to work in JEA context
+
 ## 1.1.1 (2021-07-07)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-apichecks/milestone/4?closed=1)

--- a/lib/Invoke-IcingaApiChecksRESTCall.psm1
+++ b/lib/Invoke-IcingaApiChecksRESTCall.psm1
@@ -7,6 +7,8 @@ function Invoke-IcingaApiChecksRESTCall()
         [string]$ApiVersion    = $null
     );
 
+    $Global:IcingaDaemonData = $IcingaGlobals;
+
     # Initialise some global variables we use to actually store check result data from
     # plugins properly. This is doable from each thread instance as this part isn't
     # shared between daemons
@@ -91,9 +93,9 @@ function Invoke-IcingaApiChecksRESTCall()
                     -Value $_.Value | Out-Null;
             };
 
-            [int]$ExitCode = Invoke-Command -ScriptBlock { return &$ExecuteCommand @Arguments };
+            [int]$ExitCode = & $ExecuteCommand @Arguments;
         } elseif ($Request.Method -eq 'GET') {
-            [int]$ExitCode = Invoke-Command -ScriptBlock { return &$ExecuteCommand };
+            [int]$ExitCode = & $ExecuteCommand;
         } else {
             Send-IcingaTCPClientMessage -Message (
                 New-IcingaTCPClientRESTMessage `


### PR DESCRIPTION
In order for the Api-Checks to work in JEA context, we will have to get rid of all `ScriptBlocks` and replace them with other methods.