### PR TITLE
Fix PerfData should always return as array

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -6,9 +6,13 @@ Please read the [upgrading](30-Upgrading-API-Checks.md) documentation before upg
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-apichecks/milestones?state=closed).
 
-## 1.2.0 (2021-03-02)
+## 1.2.0 (2021-09-07)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-apichecks/milestone/3?closed=1)
+
+### Bugfixes
+
+* [#5](https://github.com/Icinga/icinga-powershell-apichecks/issues/5) Fixes performance data for executed checks, which did not return an empty array if no data was available or perf data were disabled
 
 ## 1.1.1 (2021-07-07)
 

--- a/lib/Invoke-IcingaApiChecksRESTCall.psm1
+++ b/lib/Invoke-IcingaApiChecksRESTCall.psm1
@@ -105,8 +105,13 @@ function Invoke-IcingaApiChecksRESTCall()
 
         # Once the check is executed, the plugin output and the performance data are stored
         # within a special cache map we can use for accessing
-        $CheckResult = Get-IcingaCheckSchedulerPluginOutput;
-        $PerfData    = Get-IcingaCheckSchedulerPerfData;
+        $CheckResult     = Get-IcingaCheckSchedulerPluginOutput;
+        [array]$PerfData = Get-IcingaCheckSchedulerPerfData;
+
+        # Ensure our PerfData variable is always an array
+        if ($null -eq $PerfData -Or $PerfData.Count -eq 0) {
+            [array]$PerfData = @();
+        }
 
         # Free our memory again
         Clear-IcingaCheckSchedulerEnvironment;


### PR DESCRIPTION
Fixes performance data for executed checks, which did not return an empty array if no data was available or perf data were disabled

Fixes #5