### PR TITLE
Fix: Checker could return invalid exit code if no command is executed

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#5](https://github.com/Icinga/icinga-powershell-apichecks/issues/5) Fixes performance data for executed checks, which did not return an empty array if no data was available or perf data were disabled
+* [#6](https://github.com/Icinga/icinga-powershell-apichecks/issues/6) Fixes exit code to always return an integer and in case not being used, always 3 for `UNKNOWN` in Icinga context
 
 ## 1.1.1 (2021-07-07)
 

--- a/lib/Invoke-IcingaApiChecksRESTCall.psm1
+++ b/lib/Invoke-IcingaApiChecksRESTCall.psm1
@@ -17,6 +17,7 @@ function Invoke-IcingaApiChecksRESTCall()
     # Short our call
     $CheckerAliases = $IcingaGlobals.BackgroundDaemon.IcingaPowerShellRestApi.CommandAliases.checker;
     $CheckConfig    = $Request.Body;
+    [int]$ExitCode  = 3; #Unknown
 
     # Check if there are an inventory aliases configured
     # This should be maintained by the developer and not occur
@@ -90,9 +91,9 @@ function Invoke-IcingaApiChecksRESTCall()
                     -Value $_.Value | Out-Null;
             };
 
-            $ExitCode = Invoke-Command -ScriptBlock { return &$ExecuteCommand @Arguments };
+            [int]$ExitCode = Invoke-Command -ScriptBlock { return &$ExecuteCommand @Arguments };
         } elseif ($Request.Method -eq 'GET') {
-            $ExitCode = Invoke-Command -ScriptBlock { return &$ExecuteCommand };
+            [int]$ExitCode = Invoke-Command -ScriptBlock { return &$ExecuteCommand };
         } else {
             Send-IcingaTCPClientMessage -Message (
                 New-IcingaTCPClientRESTMessage `


### PR DESCRIPTION
We should always return a proper exit code while running checks. If nothing is executed and a check result is returned, we now dafault to 3 for `UNKNOWN` in Icinga context.

Fixes #6